### PR TITLE
feat: add engagement trend charts to analytics dashboard

### DIFF
--- a/catalog-analytics/app/analytics-content.tsx
+++ b/catalog-analytics/app/analytics-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState, useEffect } from "react";
+import { GitHubTrendsSection, PyPITrendsSection } from "./trends-tab";
 import { motion } from "framer-motion";
 import {
   Star,
@@ -786,41 +787,7 @@ export default function AnalyticsPage({ user }: AnalyticsPageProps) {
               </div>
             </section>
 
-            {/* Top Performers */}
-            <section className="mb-12">
-              <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6 flex items-center gap-2">
-                <Award className="w-6 h-6 text-vector-magenta" />
-                Top Performers
-              </h2>
-              <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-                {/* Most Cloned */}
-                <TopPerformerCard
-                  title="Most Cloned (14d)"
-                  icon={<Download className="w-5 h-5 text-vector-magenta" />}
-                  repos={topPerformers.byCloners}
-                  valueKey="unique_cloners"
-                  valueLabel="cloners"
-                />
-
-                {/* Most Visited */}
-                <TopPerformerCard
-                  title="Most Visited (14d)"
-                  icon={<Eye className="w-5 h-5 text-vector-magenta" />}
-                  repos={topPerformers.byVisitors}
-                  valueKey="unique_visitors"
-                  valueLabel="visitors"
-                />
-
-                {/* Most Starred */}
-                <TopPerformerCard
-                  title="Most Starred"
-                  icon={<Star className="w-5 h-5 text-vector-magenta" />}
-                  repos={topPerformers.byStars}
-                  valueKey="stars"
-                  valueLabel="stars"
-                />
-              </div>
-            </section>
+            <GitHubTrendsSection historicalData={historicalData} />
 
             {/* Repositories Table */}
             <RepositoryTable
@@ -978,36 +945,7 @@ export default function AnalyticsPage({ user }: AnalyticsPageProps) {
                       </div>
                     </section>
 
-                    {/* Top Performers */}
-                    <section className="mb-12">
-                      <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6 flex items-center gap-2">
-                        <Award className="w-6 h-6 text-vector-magenta" />
-                        Top Performers
-                      </h2>
-                      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-                        <TopPypiPerformerCard
-                          title="Most Downloaded (Last Day)"
-                          icon={<Download className="w-5 h-5 text-vector-magenta" />}
-                          packages={topPypiPerformers.byDay}
-                          valueKey="downloads_last_day"
-                          valueLabel="downloads"
-                        />
-                        <TopPypiPerformerCard
-                          title="Most Downloaded (Last Week)"
-                          icon={<Download className="w-5 h-5 text-vector-magenta" />}
-                          packages={topPypiPerformers.byWeek}
-                          valueKey="downloads_last_week"
-                          valueLabel="downloads"
-                        />
-                        <TopPypiPerformerCard
-                          title="Most Downloaded (Last Month)"
-                          icon={<Download className="w-5 h-5 text-vector-magenta" />}
-                          packages={topPypiPerformers.byMonth}
-                          valueKey="downloads_last_month"
-                          valueLabel="downloads"
-                        />
-                      </div>
-                    </section>
+                    <PyPITrendsSection historicalData={pypiData} />
 
                     {/* All Packages Table */}
                     <section>

--- a/catalog-analytics/app/trends-tab.tsx
+++ b/catalog-analytics/app/trends-tab.tsx
@@ -1,0 +1,775 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import {
+  AreaChart,
+  Area,
+  ComposedChart,
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { TrendingUp, Star, Users, GitBranch, Download, ChevronDown } from "lucide-react";
+
+// ── Shared types (structurally compatible with analytics-content.tsx) ─────────
+
+interface RepoSnapshot {
+  timestamp: string;
+  stars: number;
+  unique_visitors_14d: number | null;
+  unique_cloners_14d: number | null;
+}
+
+interface RepoHistory {
+  name: string;
+  snapshots: RepoSnapshot[];
+}
+
+interface GitHubHistoricalData {
+  repos: Record<string, RepoHistory>;
+  last_updated: string | null;
+}
+
+interface PyPISnapshot {
+  timestamp: string;
+  downloads_last_week: number | null;
+  downloads_last_month: number | null;
+}
+
+interface PyPIPackageHistory {
+  name: string;
+  repo_id: string;
+  type: string;
+  snapshots: PyPISnapshot[];
+}
+
+interface PyPIHistoricalData {
+  packages: Record<string, PyPIPackageHistory>;
+  last_updated: string | null;
+}
+
+type GitHubMetric = "unique_cloners_14d" | "unique_visitors_14d";
+type PyPIMetric = "downloads_last_week" | "downloads_last_month";
+
+interface TrafficPoint {
+  label: string;
+  raw: number | null;
+  avg4w: number | null;
+}
+
+interface AggregatePoint {
+  label: string;
+  starsGained: number;
+}
+
+interface TopMover {
+  id: string;
+  name: string;
+  earlyAvg: number;
+  recentAvg: number;
+  delta: number;
+  growthPct: number | null;
+}
+
+interface TooltipEntry {
+  name: string;
+  value: number | null;
+  color: string;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const BRAND = {
+  magenta: "#EB088A",
+  cobalt: "#313CFF",
+  violet: "#8A25C9",
+  tangerine: "#FF9E00",
+} as const;
+
+const GITHUB_METRIC_META: Record<
+  GitHubMetric,
+  { label: string; shortLabel: string; color: string }
+> = {
+  unique_cloners_14d: {
+    label: "Unique Cloners",
+    shortLabel: "cloners",
+    color: BRAND.cobalt,
+  },
+  unique_visitors_14d: {
+    label: "Unique Visitors",
+    shortLabel: "visitors",
+    color: BRAND.violet,
+  },
+};
+
+const PYPI_METRIC_META: Record<
+  PyPIMetric,
+  { label: string; shortLabel: string; color: string }
+> = {
+  downloads_last_week: {
+    label: "Weekly Downloads",
+    shortLabel: "weekly",
+    color: BRAND.tangerine,
+  },
+  downloads_last_month: {
+    label: "Monthly Downloads",
+    shortLabel: "monthly",
+    color: BRAND.cobalt,
+  },
+};
+
+// ── Data helpers ──────────────────────────────────────────────────────────────
+
+function mondayOf(timestamp: string): string {
+  const d = new Date(timestamp);
+  const day = d.getDay(); // 0 = Sun
+  d.setDate(d.getDate() - (day === 0 ? 6 : day - 1));
+  return d.toISOString().slice(0, 10);
+}
+
+function weekLabel(isoDate: string): string {
+  const d = new Date(isoDate + "T12:00:00Z");
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    year: "2-digit",
+    timeZone: "UTC",
+  });
+}
+
+function dedupeByWeek<T extends { timestamp: string }>(snapshots: T[]): T[] {
+  const map = new Map<string, T>();
+  for (const snap of snapshots) {
+    map.set(mondayOf(snap.timestamp), snap);
+  }
+  return [...map.values()].sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+  );
+}
+
+function movingAvg(
+  values: (number | null)[],
+  window: number
+): (number | null)[] {
+  return values.map((_, i) => {
+    const slice = values.slice(Math.max(0, i - window + 1), i + 1);
+    const valid = slice.filter((v): v is number => v !== null);
+    // require at least half the window to avoid misleading early points
+    if (valid.length < Math.ceil(window / 2)) return null;
+    return Math.round(valid.reduce((s, v) => s + v, 0) / valid.length);
+  });
+}
+
+function computeTopMovers<T extends { timestamp: string }>(
+  entries: [string, { name: string; snapshots: T[] }][],
+  getValue: (s: T) => number | null,
+  n = 8
+): TopMover[] {
+  const WINDOW = 4;
+  return entries
+    .map(([id, entry]) => {
+      const snaps = dedupeByWeek(entry.snapshots);
+      if (snaps.length < WINDOW * 2) return null;
+
+      const vals = snaps.map((s) => getValue(s) ?? 0);
+      const earlyAvg =
+        vals.slice(0, WINDOW).reduce((s, v) => s + v, 0) / WINDOW;
+      const recentAvg =
+        vals.slice(-WINDOW).reduce((s, v) => s + v, 0) / WINDOW;
+      const delta = recentAvg - earlyAvg;
+      const growthPct =
+        earlyAvg > 0 ? Math.round((delta / earlyAvg) * 100) : null;
+
+      return {
+        id,
+        name: entry.name,
+        earlyAvg: Math.round(earlyAvg),
+        recentAvg: Math.round(recentAvg),
+        delta: Math.round(delta),
+        growthPct,
+      } satisfies TopMover;
+    })
+    .filter((m): m is TopMover => m !== null && m.delta > 0)
+    .sort((a, b) => b.delta - a.delta)
+    .slice(0, n);
+}
+
+// ── Shared UI primitives ──────────────────────────────────────────────────────
+
+function ChartNote({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 mb-4">
+      {children}
+    </p>
+  );
+}
+
+function ChartTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: TooltipEntry[];
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 shadow-lg text-sm">
+      <p className="font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+        {label}
+      </p>
+      {payload.map((entry) => (
+        <p key={entry.name} className="text-xs text-gray-500 dark:text-gray-400">
+          <span className="font-semibold" style={{ color: entry.color }}>
+            {entry.name}:
+          </span>{" "}
+          {entry.value !== null ? entry.value.toLocaleString() : "—"}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+function MetricToggle<M extends string>({
+  options,
+  active,
+  onChange,
+}: {
+  options: Record<M, { label: string }>;
+  active: M;
+  onChange: (m: M) => void;
+}) {
+  return (
+    <div className="flex rounded-lg border border-gray-200 dark:border-gray-700 text-sm overflow-hidden">
+      {(Object.keys(options) as M[]).map((m) => (
+        <button
+          key={m}
+          onClick={() => onChange(m)}
+          className={`px-3 py-1.5 transition-colors ${
+            active === m
+              ? "bg-vector-magenta text-white"
+              : "text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800"
+          }`}
+        >
+          {options[m].label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function RepoSelector({
+  repos,
+  value,
+  onChange,
+}: {
+  repos: [string, string][];
+  value: string;
+  onChange: (id: string) => void;
+}) {
+  return (
+    <div className="relative">
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="appearance-none bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg pl-3 pr-8 py-1.5 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-vector-magenta cursor-pointer"
+      >
+        {repos.map(([id, name]) => (
+          <option key={id} value={id}>
+            {name}
+          </option>
+        ))}
+      </select>
+      <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+    </div>
+  );
+}
+
+// bars = raw weekly snapshot, line = 4-week moving average
+function SpotlightChart({
+  data,
+  color,
+}: {
+  data: TrafficPoint[];
+  color: string;
+}) {
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <ComposedChart data={data} margin={{ top: 5, right: 8, bottom: 0, left: 0 }}>
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke="#e5e7eb"
+          strokeOpacity={0.6}
+        />
+        <XAxis
+          dataKey="label"
+          tick={{ fontSize: 11, fill: "#9ca3af" }}
+          tickLine={false}
+          axisLine={false}
+          interval="preserveStartEnd"
+        />
+        <YAxis
+          tick={{ fontSize: 11, fill: "#9ca3af" }}
+          tickLine={false}
+          axisLine={false}
+          width={44}
+          allowDecimals={false}
+          tickFormatter={(v) =>
+            v >= 1000 ? `${(v / 1000).toFixed(1)}k` : String(v)
+          }
+        />
+        <Tooltip content={<ChartTooltip />} />
+        <Bar
+          dataKey="raw"
+          name="Weekly snapshot"
+          fill={color}
+          fillOpacity={0.2}
+          radius={[2, 2, 0, 0]}
+        />
+        <Line
+          type="monotone"
+          dataKey="avg4w"
+          name="4-week avg"
+          stroke={color}
+          strokeWidth={2.5}
+          dot={false}
+          activeDot={{ r: 4, fill: color, strokeWidth: 0 }}
+          connectNulls
+        />
+      </ComposedChart>
+    </ResponsiveContainer>
+  );
+}
+
+function TopMoversPanel({
+  movers,
+  color,
+  shortLabel,
+}: {
+  movers: TopMover[];
+  color: string;
+  shortLabel: string;
+}) {
+  const maxRecent = movers[0]?.recentAvg ?? 1;
+
+  if (movers.length === 0) {
+    return (
+      <p className="text-sm text-gray-400 dark:text-gray-500 py-4">
+        Not enough historical data yet.
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <div className="space-y-3">
+        {movers.map((m, i) => {
+          const barPct = Math.min(
+            100,
+            Math.round((m.recentAvg / maxRecent) * 100)
+          );
+          return (
+            <div key={m.id} className="flex items-center gap-2.5">
+              <span className="w-4 text-xs text-gray-400 text-right flex-shrink-0">
+                {i + 1}
+              </span>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-baseline justify-between gap-1 mb-1">
+                  <a
+                    href={`https://github.com/${m.id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm font-medium text-gray-900 dark:text-white hover:text-vector-magenta truncate"
+                  >
+                    {m.name}
+                  </a>
+                  <span
+                    className="text-xs flex-shrink-0 font-semibold"
+                    style={{ color }}
+                  >
+                    +{m.delta.toLocaleString()}
+                    {m.growthPct !== null && (
+                      <span className="text-gray-400 font-normal ml-1">
+                        ({m.growthPct > 0 ? "+" : ""}
+                        {m.growthPct}%)
+                      </span>
+                    )}
+                  </span>
+                </div>
+                <div className="h-1 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
+                  <div
+                    className="h-full rounded-full"
+                    style={{
+                      width: `${barPct}%`,
+                      backgroundColor: color,
+                      opacity: 0.65,
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <p className="text-xs text-gray-400 dark:text-gray-500 mt-3">
+        Δ = avg of last 4 weeks − avg of first 4 weeks ·{" "}
+        <span className="italic">unique {shortLabel} / 14-day window</span>
+      </p>
+    </>
+  );
+}
+
+// ── GitHub Trends Section ────────────────────────────────────────────────────
+
+function buildAggregateStarsSeries(
+  repos: Record<string, RepoHistory>
+): AggregatePoint[] {
+  const weekSet = new Set<string>();
+  const repoWeekMaps = new Map<string, Map<string, number>>();
+
+  for (const [repoId, repo] of Object.entries(repos)) {
+    const deduped = dedupeByWeek(repo.snapshots);
+    const weekMap = new Map<string, number>();
+    for (const snap of deduped) {
+      const week = mondayOf(snap.timestamp);
+      weekSet.add(week);
+      weekMap.set(week, snap.stars);
+    }
+    repoWeekMaps.set(repoId, weekMap);
+  }
+
+  const sortedWeeks = [...weekSet].sort();
+  const repoLastKnown = new Map<string, number>();
+
+  const raw = sortedWeeks.map((week) => {
+    let total = 0;
+    for (const [repoId, weekMap] of repoWeekMaps) {
+      if (weekMap.has(week)) {
+        repoLastKnown.set(repoId, weekMap.get(week)!);
+      }
+      total += repoLastKnown.get(repoId) ?? 0;
+    }
+    return { week, label: weekLabel(week), total };
+  });
+
+  const baseline = raw[0]?.total ?? 0;
+  return raw.map((pt) => ({
+    label: pt.label,
+    starsGained: pt.total - baseline,
+  }));
+}
+
+function buildGitHubSpotlightSeries(
+  snapshots: RepoSnapshot[],
+  metric: GitHubMetric
+): TrafficPoint[] {
+  const deduped = dedupeByWeek(snapshots);
+  const rawValues = deduped.map((s) => s[metric] ?? null);
+  const avgValues = movingAvg(rawValues, 4);
+  return deduped.map((snap, i) => ({
+    label: weekLabel(mondayOf(snap.timestamp)),
+    raw: rawValues[i],
+    avg4w: avgValues[i],
+  }));
+}
+
+export function GitHubTrendsSection({
+  historicalData,
+}: {
+  historicalData: GitHubHistoricalData | null;
+}) {
+  const [selectedRepoId, setSelectedRepoId] = useState("");
+  const [metric, setMetric] = useState<GitHubMetric>("unique_cloners_14d");
+
+  const repos = historicalData?.repos ?? {};
+
+  const spotlightRepos = useMemo(
+    () =>
+      Object.entries(repos)
+        .filter(([, r]) => dedupeByWeek(r.snapshots).length >= 4)
+        .sort(([, a], [, b]) => a.name.localeCompare(b.name))
+        .map(([id, r]) => [id, r.name] as [string, string]),
+    [repos]
+  );
+
+  const activeRepoId = (selectedRepoId || spotlightRepos[0]?.[0]) ?? "";
+
+  const aggregateData = useMemo(
+    () => buildAggregateStarsSeries(repos),
+    [repos]
+  );
+
+  const spotlightData = useMemo(
+    () =>
+      repos[activeRepoId]
+        ? buildGitHubSpotlightSeries(repos[activeRepoId].snapshots, metric)
+        : [],
+    [repos, activeRepoId, metric]
+  );
+
+  const topMovers = useMemo(
+    () =>
+      computeTopMovers(
+        Object.entries(repos),
+        (s: RepoSnapshot) => s[metric] ?? null
+      ),
+    [repos, metric]
+  );
+
+  const gained = aggregateData.at(-1)?.starsGained ?? 0;
+  const since = aggregateData[0]?.label ?? "";
+  const { color, shortLabel } = GITHUB_METRIC_META[metric];
+
+  if (!historicalData) return null;
+
+  return (
+    <section className="mb-12">
+      <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6 flex items-center gap-2">
+        <TrendingUp className="w-6 h-6 text-vector-magenta" />
+        Trends
+      </h2>
+
+      {/* Stars growth */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6 shadow-sm mb-6">
+        <div className="flex items-start justify-between mb-0.5">
+          <h3 className="text-base font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+            <Star className="w-5 h-5 text-vector-magenta" />
+            Portfolio Stars Growth
+          </h3>
+          {gained > 0 && (
+            <span className="text-sm font-medium text-green-600 dark:text-green-400">
+              +{gained.toLocaleString()} since {since}
+            </span>
+          )}
+        </div>
+        <ChartNote>
+          Cumulative new stars across all repositories. Stars are direct human
+          actions — no CI/CD noise.
+        </ChartNote>
+        <ResponsiveContainer width="100%" height={200}>
+          <AreaChart
+            data={aggregateData}
+            margin={{ top: 5, right: 8, bottom: 0, left: 0 }}
+          >
+            <defs>
+              <linearGradient id="starsGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor={BRAND.magenta} stopOpacity={0.2} />
+                <stop offset="95%" stopColor={BRAND.magenta} stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke="#e5e7eb"
+              strokeOpacity={0.6}
+            />
+            <XAxis
+              dataKey="label"
+              tick={{ fontSize: 11, fill: "#9ca3af" }}
+              tickLine={false}
+              axisLine={false}
+              interval="preserveStartEnd"
+            />
+            <YAxis
+              tick={{ fontSize: 11, fill: "#9ca3af" }}
+              tickLine={false}
+              axisLine={false}
+              width={36}
+              allowDecimals={false}
+            />
+            <Tooltip content={<ChartTooltip />} />
+            <Area
+              type="monotone"
+              dataKey="starsGained"
+              name="Stars gained"
+              stroke={BRAND.magenta}
+              strokeWidth={2}
+              fill="url(#starsGradient)"
+              dot={false}
+              activeDot={{ r: 4, fill: BRAND.magenta, strokeWidth: 0 }}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Spotlight + Top Movers */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6 shadow-sm">
+          {/* Controls */}
+          <div className="flex flex-wrap items-center gap-3 mb-4">
+            <MetricToggle
+              options={{
+                unique_cloners_14d: { label: "Unique Cloners" },
+                unique_visitors_14d: { label: "Unique Visitors" },
+              }}
+              active={metric}
+              onChange={(m) => {
+                setMetric(m);
+                setSelectedRepoId("");
+              }}
+            />
+            <RepoSelector
+              repos={spotlightRepos}
+              value={activeRepoId}
+              onChange={setSelectedRepoId}
+            />
+          </div>
+          <ChartNote>
+            Bars = raw 14-day window each week · line = 4-week moving average
+            (smooths CI/CD noise)
+          </ChartNote>
+          {spotlightData.length >= 4 ? (
+            <SpotlightChart data={spotlightData} color={color} />
+          ) : (
+            <p className="text-sm text-gray-400 py-10 text-center">
+              Not enough data for this repository.
+            </p>
+          )}
+        </div>
+
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6 shadow-sm">
+          <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-0.5 flex items-center gap-2">
+            {metric === "unique_cloners_14d" ? (
+              <GitBranch className="w-4 h-4" style={{ color }} />
+            ) : (
+              <Users className="w-4 h-4" style={{ color }} />
+            )}
+            Top Movers
+          </h3>
+          <ChartNote>
+            Repos with the highest growth in unique {shortLabel} over 7 months.
+          </ChartNote>
+          <TopMoversPanel
+            movers={topMovers}
+            color={color}
+            shortLabel={shortLabel}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ── PyPI Trends Section ───────────────────────────────────────────────────────
+
+function buildPyPISpotlightSeries(
+  snapshots: PyPISnapshot[],
+  metric: PyPIMetric
+): TrafficPoint[] {
+  const deduped = dedupeByWeek(snapshots);
+  const rawValues = deduped.map((s) => s[metric] ?? null);
+  const avgValues = movingAvg(rawValues, 4);
+  return deduped.map((snap, i) => ({
+    label: weekLabel(mondayOf(snap.timestamp)),
+    raw: rawValues[i],
+    avg4w: avgValues[i],
+  }));
+}
+
+export function PyPITrendsSection({
+  historicalData,
+}: {
+  historicalData: PyPIHistoricalData | null;
+}) {
+  const [selectedPackage, setSelectedPackage] = useState("");
+  const [metric, setMetric] = useState<PyPIMetric>("downloads_last_week");
+
+  const packages = historicalData?.packages ?? {};
+
+  const packageList = useMemo(
+    () =>
+      Object.entries(packages)
+        .filter(([, p]) => dedupeByWeek(p.snapshots).length >= 4)
+        .sort(([, a], [, b]) => a.name.localeCompare(b.name))
+        .map(([id, p]) => [id, p.name] as [string, string]),
+    [packages]
+  );
+
+  const activePackage = (selectedPackage || packageList[0]?.[0]) ?? "";
+
+  const spotlightData = useMemo(
+    () =>
+      packages[activePackage]
+        ? buildPyPISpotlightSeries(packages[activePackage].snapshots, metric)
+        : [],
+    [packages, activePackage, metric]
+  );
+
+  const topMovers = useMemo(
+    () =>
+      computeTopMovers(
+        Object.entries(packages).map(([id, p]) => [
+          id,
+          { name: p.name, snapshots: p.snapshots },
+        ]),
+        (s: PyPISnapshot) => s[metric] ?? null
+      ),
+    [packages, metric]
+  );
+
+  const { color, shortLabel } = PYPI_METRIC_META[metric];
+
+  if (!historicalData || packageList.length === 0) return null;
+
+  return (
+    <section className="mb-12">
+      <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6 flex items-center gap-2">
+        <TrendingUp className="w-6 h-6 text-vector-magenta" />
+        Trends
+      </h2>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6 shadow-sm">
+          {/* Controls */}
+          <div className="flex flex-wrap items-center gap-3 mb-4">
+            <MetricToggle
+              options={{
+                downloads_last_week: { label: "Weekly" },
+                downloads_last_month: { label: "Monthly" },
+              }}
+              active={metric}
+              onChange={(m) => {
+                setMetric(m);
+                setSelectedPackage("");
+              }}
+            />
+            <RepoSelector
+              repos={packageList}
+              value={activePackage}
+              onChange={setSelectedPackage}
+            />
+          </div>
+          <ChartNote>
+            Bars = raw {shortLabel} download count each snapshot · line = 4-week
+            moving average (smooths CI/CD noise)
+          </ChartNote>
+          {spotlightData.length >= 4 ? (
+            <SpotlightChart data={spotlightData} color={color} />
+          ) : (
+            <p className="text-sm text-gray-400 py-10 text-center">
+              Not enough data for this package.
+            </p>
+          )}
+        </div>
+
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6 shadow-sm">
+          <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-0.5 flex items-center gap-2">
+            <Download className="w-4 h-4" style={{ color }} />
+            Top Movers
+          </h3>
+          <ChartNote>
+            Packages with the highest growth in {shortLabel} downloads over 7 months.
+          </ChartNote>
+          <TopMoversPanel
+            movers={topMovers}
+            color={color}
+            shortLabel={shortLabel + " downloads"}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/catalog-analytics/package-lock.json
+++ b/catalog-analytics/package-lock.json
@@ -14,7 +14,8 @@
         "lucide-react": "^0.468.0",
         "next": "16.2.6",
         "react": "19.0.0",
-        "react-dom": "19.0.0"
+        "react-dom": "19.0.0",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -980,6 +981,42 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -992,6 +1029,18 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.15.0.tgz",
       "integrity": "sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -1013,6 +1062,69 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1049,7 +1161,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1064,6 +1176,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.48.1",
@@ -2190,6 +2308,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2268,8 +2395,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2349,6 +2597,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2635,6 +2889,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.1.tgz",
+      "integrity": "sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -3083,6 +3347,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3569,6 +3839,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3609,6 +3889,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/iron-session": {
@@ -5042,8 +5331,30 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -5066,6 +5377,51 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5111,6 +5467,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -5784,6 +6146,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6097,12 +6465,43 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/catalog-analytics/package.json
+++ b/catalog-analytics/package.json
@@ -15,7 +15,8 @@
     "lucide-react": "^0.468.0",
     "next": "16.2.6",
     "react": "19.0.0",
-    "react-dom": "19.0.0"
+    "react-dom": "19.0.0",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/catalog-analytics/tsconfig.json
+++ b/catalog-analytics/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary

- Replaces static "Top Performers" cards in both GitHub and PyPI tabs with time-series trend charts backed by 7 months of existing weekly historical data
- Adds **Portfolio Stars Growth** area chart (cumulative across all repos — clean human signal, no CI/CD noise)
- Adds **Engagement Spotlight** per repo/package: bars show the raw 14-day window snapshot each week; a 4-week moving average line smooths CI/CD automation noise to surface real engagement trends
- Adds **Top Movers** panel ranking by delta between first-4-weeks avg and last-4-weeks avg (more robust to outliers than a single first/last comparison)
- Adds `recharts` dependency; all chart logic lives in a new self-contained module `catalog-analytics/app/trends-tab.tsx`

## Motivation

Absolute download/clone counts are heavily inflated by CI/CD pipelines. The 4-week moving average of the 14-day rolling window makes week-over-week changes attributable to actual engagement. The portfolio stars chart is the cleanest signal — stars are human actions.

## Test plan

- [ ] Visit `/analytics` → GitHub Metrics tab: confirm Stars Growth chart renders, Spotlight chart responds to metric toggle and repo selector, Top Movers list populates
- [ ] Visit PyPI Metrics tab: confirm Spotlight and Top Movers render for weekly/monthly toggle
- [ ] Verify dark mode styling is consistent with the rest of the dashboard
- [ ] Deploy preview via Cloud Run (`deploy-catalog-analytics` workflow)